### PR TITLE
find blender scripts in symlinks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -440,7 +440,7 @@
         {
             "label": "Update Blender Sources [Checks out master branch]",
             "type": "shell",
-            "command": "make",
+            "command": "./make",
             "args": [
                 "update"
             ],

--- a/blenderpy/__init__.py
+++ b/blenderpy/__init__.py
@@ -42,7 +42,7 @@ SYSTEM_NAME = platform.system()
 
 def find_blender_scripts_directory(search_root: str) -> Optional[str]:
 
-    for _dir, _dirs, _files in os.walk(search_root):
+    for _dir, _dirs, _files in os.walk(search_root, followlinks=True):
 
         if re.match(BLENDER_SCRIPTS_DIR_REGEX, os.path.basename(_dir)) and\
            all([entry in _dirs for entry in ["datafiles", "scripts"]]):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ SYSTEM_OS_NAME = platform.system()
 # Change the Blender desired API version variable to build different versions
 # of the Blender API. For instance, 'v2.79b' is the same version of the API
 # as you would get when opening the Blender application at v2.79b
-VERSION = "2.91"
+VERSION = "2.93"
 VERSION_TUPLE = pkg_resources.parse_version(VERSION)
 
 class CMakeExtension(Extension):
@@ -349,7 +349,7 @@ class BuildCMakeExt(build_ext):
         # different place. See comments above for additional information
 
 setup(name='bpy',
-      version="2.92a0",
+      version="2.93a0",
       packages=find_packages(),
       ext_modules=[CMakeExtension(name="bpy")],
       entry_points={


### PR DESCRIPTION
- os.walk needs "followlinks" as true to support symlinks
- affects the pre_uninstall and post_install scripts
- Fixes #83 